### PR TITLE
Updated xerces to version 2.11.0

### DIFF
--- a/jsprit-analysis/pom.xml
+++ b/jsprit-analysis/pom.xml
@@ -43,7 +43,7 @@
   	<dependency>
   		<groupId>org.jfree</groupId>
   		<artifactId>jfreechart</artifactId>
-  		<version>1.0.14</version>
+  		<version>1.0.19</version>
   		<scope>compile</scope>
   	</dependency>
   	

--- a/jsprit-core/pom.xml
+++ b/jsprit-core/pom.xml
@@ -77,8 +77,8 @@
 
     <dependency>
     	<groupId>xerces</groupId>
-    	<artifactId>xerces</artifactId>
-    	<version>2.4.0</version>
+    	<artifactId>xercesImpl</artifactId>
+    	<version>2.11.0</version>
     	<scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
Also updated jfreechart from 1.0.14 to 1.0.19 to avoid a transitive
dependency on xml-apis v1.3.04 which might clash with the xml-apis
v1.4.01 that is pulled in by the new xerces version.

The current versions of xerces and xml-apis are clashing with the versions pulled in by other libraries (I use Spring Boot and Hazelcast).

See http://stackoverflow.com/a/15265458/101434 for more information.