### PR TITLE
[Fix #173] Updated all logging statements to use parameter substitution

### DIFF
--- a/jsprit-core/src/main/java/jsprit/core/algorithm/SearchStrategy.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/SearchStrategy.java
@@ -88,7 +88,7 @@ public class SearchStrategy {
         this.solutionAcceptor = solutionAcceptor;
         this.solutionCostCalculator = solutionCostCalculator;
         this.id = id;
-        logger.debug("initialise " + this);
+        logger.debug("initialise {}", this);
     }
 
     public String getId() {
@@ -159,7 +159,7 @@ public class SearchStrategy {
     public void addModule(SearchStrategyModule module){
 		if(module == null) throw new IllegalStateException("module to be added is null.");
 		searchStrategyModules.add(module);
-		logger.debug("module added [module=" + module + "][#modules=" + searchStrategyModules.size() + "]");
+		logger.debug("module added [module={}][#modules={}]", module, searchStrategyModules.size());
 	}
 
 	public void addModuleListener(SearchStrategyModuleListener moduleListener) {

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/VehicleRoutingAlgorithm.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/VehicleRoutingAlgorithm.java
@@ -142,8 +142,8 @@ public class VehicleRoutingAlgorithm {
             }
         }
         if(nuJobs != problem.getJobs().values().size()){
-            logger.warn("number of jobs in initial solution (" + nuJobs + ") is not equal nuJobs in vehicle routing problem (" + problem.getJobs().values().size() + ")" +
-                    "\n this might yield unintended effects, e.g. initial solution cannot be improved anymore.");
+            logger.warn("number of jobs in initial solution ({}) is not equal nuJobs in vehicle routing problem ({})" +
+                    "\n this might yield unintended effects, e.g. initial solution cannot be improved anymore.", nuJobs, problem.getJobs().values().size() );
         }
     }
 
@@ -188,7 +188,7 @@ public class VehicleRoutingAlgorithm {
 	 * @see {@link SearchStrategyManager}, {@link VehicleRoutingAlgorithmListener}, {@link AlgorithmStartsListener}, {@link AlgorithmEndsListener}, {@link IterationStartsListener}, {@link IterationEndsListener}
 	 */
 	public Collection<VehicleRoutingProblemSolution> searchSolutions(){
-		logger.info("algorithm starts: " + "[maxIterations=" + maxIterations + "]");
+		logger.info("algorithm starts: [maxIterations={}]", maxIterations);
 		double now = System.currentTimeMillis();
 		int noIterationsThisAlgoIsRunning = maxIterations;
 		counter.reset();
@@ -198,24 +198,24 @@ public class VehicleRoutingAlgorithm {
         logger.info("iterations start");
 		for(int i=0;i< maxIterations;i++){
 			iterationStarts(i+1,problem,solutions);
-			logger.debug("start iteration: " + i);
+			logger.debug("start iteration: {}", i);
 			counter.incCounter();
 			SearchStrategy strategy = searchStrategyManager.getRandomStrategy();
 			DiscoveredSolution discoveredSolution = strategy.run(problem, solutions);
-			logger.trace("discovered solution: " + discoveredSolution);
+			logger.trace("discovered solution: {}", discoveredSolution);
             memorizeIfBestEver(discoveredSolution);
 			selectedStrategy(discoveredSolution,problem,solutions);
             if(terminationManager.isPrematureBreak(discoveredSolution)){
-				logger.info("premature algorithm termination at iteration "+ (i+1));
+				logger.info("premature algorithm termination at iteration {}", (i+1));
 				noIterationsThisAlgoIsRunning = (i+1);
 				break;
 			}
 			iterationEnds(i+1,problem,solutions);
 		}
-		logger.info("iterations end at " + noIterationsThisAlgoIsRunning + " iterations");
+		logger.info("iterations end at {} iterations", noIterationsThisAlgoIsRunning);
 		addBestEver(solutions);
         algorithmEnds(problem, solutions);
-		logger.info("took " + ((System.currentTimeMillis()-now)/1000.0) + " seconds");
+		logger.info("took {} seconds", ((System.currentTimeMillis()-now)/1000.0));
 		return solutions;
 	}
 
@@ -267,7 +267,7 @@ public class VehicleRoutingAlgorithm {
      */
     public void setMaxIterations(int maxIterations) {
         this.maxIterations = maxIterations;
-        logger.debug("set maxIterations to " + this.maxIterations);
+        logger.debug("set maxIterations to {}", this.maxIterations);
     }
 
     /**

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/acceptor/ExperimentalSchrimpfAcceptance.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/acceptor/ExperimentalSchrimpfAcceptance.java
@@ -57,7 +57,7 @@ public class ExperimentalSchrimpfAcceptance implements SolutionAcceptor, Iterati
 		this.alpha = alpha;
 		this.nOfRandomWalks = nOfWarmupIterations;
 		this.solutionMemory = solutionMemory;
-		logger.info("initialise " + this);
+		logger.info("initialise {}", this);
 	}
 	
 
@@ -96,7 +96,7 @@ public class ExperimentalSchrimpfAcceptance implements SolutionAcceptor, Iterati
 	
 	private double getThreshold(int iteration) {
 		double scheduleVariable = (double) iteration / (double) nOfTotalIterations;
-//		logger.debug("iter="+iteration+" totalIter="+nOfTotalIterations+" scheduling="+scheduleVariable);
+//		logger.debug("iter={} totalIter={} scheduling={}", iteration, nOfTotalIterations, scheduleVariable);
 		double currentThreshold = initialThreshold * Math.exp(-Math.log(2) * scheduleVariable / alpha);
 		return currentThreshold;
 	}
@@ -126,7 +126,7 @@ public class ExperimentalSchrimpfAcceptance implements SolutionAcceptor, Iterati
 			@Override
 			public void informIterationEnds(int iteration, VehicleRoutingProblem problem, Collection<VehicleRoutingProblemSolution> solutions) {
 				double result = Solutions.bestOf(solutions).getCost();
-//				logger.info("result="+result);
+//				logger.info("result={}", result);
 				results[iteration-1] = result;
 			}
 			
@@ -138,8 +138,8 @@ public class ExperimentalSchrimpfAcceptance implements SolutionAcceptor, Iterati
 		initialThreshold = standardDeviation / 2;
 		
 		logger.info("warmup done");
-		logger.info("total time: " + ((System.currentTimeMillis()-now)/1000.0) + "s");
-		logger.info("initial threshold: " + initialThreshold);
+		logger.info("total time: {}s", ((System.currentTimeMillis()-now)/1000.0));
+		logger.info("initial threshold: {}", initialThreshold);
 		logger.info("---------------------------------------------------------------------");
 		
 	}

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/acceptor/SchrimpfAcceptance.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/acceptor/SchrimpfAcceptance.java
@@ -83,7 +83,7 @@ public class SchrimpfAcceptance implements SolutionAcceptor, IterationStartsList
 	public SchrimpfAcceptance(int solutionMemory, double alpha){
 		this.alpha = alpha;
 		this.solutionMemory = solutionMemory;
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 
 	@Override

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/acceptor/SchrimpfInitialThresholdGenerator.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/acceptor/SchrimpfInitialThresholdGenerator.java
@@ -67,7 +67,7 @@ public class SchrimpfInitialThresholdGenerator implements AlgorithmStartsListene
 			@Override
 			public void informIterationEnds(int iteration, VehicleRoutingProblem problem, Collection<VehicleRoutingProblemSolution> solutions) {
 				double result = Solutions.bestOf(solutions).getCost();
-//				logger.info("result="+result);
+//				logger.info("result={}", result);
 				results[iteration-1] = result;
 			}
 			
@@ -80,8 +80,8 @@ public class SchrimpfInitialThresholdGenerator implements AlgorithmStartsListene
 		
 		schrimpfAcceptance.setInitialThreshold(initialThreshold);
 
-		logger.info("took " + ((System.currentTimeMillis()-now)/1000.0) + " seconds");
-		logger.debug("initial threshold: " + initialThreshold);
+		logger.info("took {} seconds", ((System.currentTimeMillis()-now)/1000.0) );
+		logger.debug("initial threshold: {}", initialThreshold);
 		logger.info("---------------------------------------------------------------------");
 	}
 

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/AbstractInsertionStrategy.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/AbstractInsertionStrategy.java
@@ -110,7 +110,7 @@ public abstract class AbstractInsertionStrategy implements InsertionStrategy{
     }
 
     protected void insertJob(Job unassignedJob, InsertionData iData, VehicleRoute inRoute){
-        logger.trace("insert: [jobId=" + unassignedJob.getId() + "]" + iData );
+        logger.trace("insert: [jobId={}]{}", unassignedJob.getId(), iData);
         insertionsListeners.informBeforeJobInsertion(unassignedJob, iData, inRoute);
         if(!(inRoute.getVehicle().getId().equals(iData.getSelectedVehicle().getId()))){
             insertionsListeners.informVehicleSwitched(inRoute, inRoute.getVehicle(), iData.getSelectedVehicle());

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/BestInsertion.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/BestInsertion.java
@@ -56,7 +56,7 @@ public final class BestInsertion extends AbstractInsertionStrategy{
 	public BestInsertion(JobInsertionCostsCalculator jobInsertionCalculator, VehicleRoutingProblem vehicleRoutingProblem) {
 		super(vehicleRoutingProblem);
 		bestInsertionCostCalculator = jobInsertionCalculator;
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 
 	@Override

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/BestInsertionConcurrent.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/BestInsertionConcurrent.java
@@ -94,7 +94,7 @@ public final class BestInsertionConcurrent extends AbstractInsertionStrategy{
 		this.nuOfBatches = nuOfBatches;
 		bestInsertionCostCalculator = jobInsertionCalculator;
 		completionService = new ExecutorCompletionService<Insertion>(executorService);
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 
 	@Override
@@ -136,7 +136,7 @@ public final class BestInsertionConcurrent extends AbstractInsertionStrategy{
 			}
 			catch (ExecutionException e) {
 				e.printStackTrace();
-				logger.error(e.getCause().toString());
+				logger.error("Exception", e);
 				System.exit(1);
 			}
 			VehicleRoute newRoute = VehicleRoute.emptyRoute();

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/JobInsertionConsideringFixCostsCalculator.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/JobInsertionConsideringFixCostsCalculator.java
@@ -46,7 +46,7 @@ final class JobInsertionConsideringFixCostsCalculator implements JobInsertionCos
 		super();
 		this.standardServiceInsertion = standardInsertionCalculator;
 		this.stateGetter = stateGetter;
-		logger.debug("inialise " + this);
+		logger.debug("inialise {}", this);
 	}
 
 	@Override
@@ -77,7 +77,7 @@ final class JobInsertionConsideringFixCostsCalculator implements JobInsertionCos
 	
 	public void setWeightOfFixCost(double weight){
 		weight_deltaFixCost = weight;
-		logger.debug("set weightOfFixCostSaving to " + weight);
+		logger.debug("set weightOfFixCostSaving to {}", weight);
 	}
 	
 	@Override

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/RegretInsertion.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/RegretInsertion.java
@@ -203,7 +203,7 @@ public class RegretInsertion extends AbstractInsertionStrategy {
         this.scoringFunction = new DefaultScorer(vehicleRoutingProblem);
 		this.insertionCostsCalculator = jobInsertionCalculator;
         this.vrp = vehicleRoutingProblem;
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 
 	@Override

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/RegretInsertionConcurrent.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/RegretInsertionConcurrent.java
@@ -144,7 +144,7 @@ public class RegretInsertionConcurrent extends AbstractInsertionStrategy {
         }
         catch (ExecutionException e) {
             e.printStackTrace();
-            logger.error(e.getCause().toString());
+            logger.error("Exception", e);
             System.exit(1);
         }
 

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/ServiceInsertionCalculator.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/ServiceInsertionCalculator.java
@@ -70,7 +70,7 @@ final class ServiceInsertionCalculator implements JobInsertionCostsCalculator{
 		softRouteConstraint = constraintManager;
 		this.additionalTransportCostsCalculator = additionalTransportCostsCalculator;
 		additionalAccessEgressCalculator = new AdditionalAccessEgressCalculator(routingCosts);
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 
     public void setJobActivityFactory(JobActivityFactory jobActivityFactory){

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/ServiceInsertionOnRouteLevelCalculator.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/ServiceInsertionOnRouteLevelCalculator.java
@@ -81,7 +81,7 @@ final class ServiceInsertionOnRouteLevelCalculator implements JobInsertionCostsC
 
 	public void setMemorySize(int memorySize) {
 		this.memorySize = memorySize;
-		logger.debug("set [solutionMemory="+memorySize+"]");
+		logger.debug("set [solutionMemory={}]", memorySize);
 	}
 
 	public ServiceInsertionOnRouteLevelCalculator(VehicleRoutingTransportCosts vehicleRoutingCosts, VehicleRoutingActivityCosts costFunc, ActivityInsertionCostsCalculator activityInsertionCostsCalculator, HardRouteConstraint hardRouteLevelConstraint, HardActivityConstraint hardActivityLevelConstraint) {
@@ -92,7 +92,7 @@ final class ServiceInsertionOnRouteLevelCalculator implements JobInsertionCostsC
 			this.hardRouteLevelConstraint = hardRouteLevelConstraint;
 			this.hardActivityLevelConstraint = hardActivityLevelConstraint;
 			auxilliaryPathCostCalculator = new AuxilliaryCostCalculator(transportCosts, activityCosts);
-			logger.debug("initialise " + this);
+			logger.debug("initialise {}", this);
 		}
 
 
@@ -102,7 +102,7 @@ final class ServiceInsertionOnRouteLevelCalculator implements JobInsertionCostsC
 	
 	void setNuOfActsForwardLooking(int nOfActsForwardLooking) {
 		this.nuOfActsForwardLooking = nOfActsForwardLooking;
-		logger.debug("set [forwardLooking="+nOfActsForwardLooking+"]");
+		logger.debug("set [forwardLooking={}]", nOfActsForwardLooking);
 	}
 
 	@Override

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/ShipmentInsertionCalculator.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/ShipmentInsertionCalculator.java
@@ -68,7 +68,7 @@ final class ShipmentInsertionCalculator implements JobInsertionCostsCalculator{
 		this.softRouteConstraint = constraintManager;
 		this.transportCosts = routingCosts;
 		additionalAccessEgressCalculator = new AdditionalAccessEgressCalculator(routingCosts);
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 
     public void setJobActivityFactory(JobActivityFactory activityFactory){
@@ -136,7 +136,7 @@ final class ShipmentInsertionCalculator implements JobInsertionCostsCalculator{
 				nextAct = end;
 				tourEnd = true;
 			}
-//			logger.info("activity: " + i + ", act-size: " + activities.size());
+//			logger.info("activity: {}, act-size: {}", i, activities.size());
 			ConstraintsStatus pickupShipmentConstraintStatus = hardActivityLevelConstraint.fulfilled(insertionContext, prevAct, pickupShipment, nextAct, prevActEndTime);
 			if(pickupShipmentConstraintStatus.equals(ConstraintsStatus.NOT_FULFILLED)){
 				double nextActArrTime = prevActEndTime + transportCosts.getTransportTime(prevAct.getLocation(), nextAct.getLocation(), prevActEndTime, newDriver, newVehicle);

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/VehicleTypeDependentJobInsertionCalculator.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/VehicleTypeDependentJobInsertionCalculator.java
@@ -60,7 +60,7 @@ final class VehicleTypeDependentJobInsertionCalculator implements JobInsertionCo
 		this.insertionCalculator = jobInsertionCalc;
 		this.vrp = vrp;
 		getInitialVehicleIds();
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 
 	private void getInitialVehicleIds() {
@@ -89,7 +89,7 @@ final class VehicleTypeDependentJobInsertionCalculator implements JobInsertionCo
 	 * @param vehicleSwitchAllowed the vehicleSwitchAllowed to set
 	 */
 	public void setVehicleSwitchAllowed(boolean vehicleSwitchAllowed) {
-		logger.debug("set vehicleSwitchAllowed to " + vehicleSwitchAllowed);
+		logger.debug("set vehicleSwitchAllowed to {}", vehicleSwitchAllowed);
 		this.vehicleSwitchAllowed = vehicleSwitchAllowed;
 	}
 

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/AbstractRuinStrategy.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/AbstractRuinStrategy.java
@@ -63,7 +63,7 @@ public abstract class AbstractRuinStrategy implements RuinStrategy{
     public Collection<Job> ruin(Collection<VehicleRoute> vehicleRoutes){
         ruinListeners.ruinStarts(vehicleRoutes);
         Collection<Job> unassigned = ruinRoutes(vehicleRoutes);
-        logger.trace("ruin: " + "[ruined=" + unassigned.size() + "]");
+        logger.trace("ruin: [ruined={}]", unassigned.size());
         ruinListeners.ruinEnds(vehicleRoutes,unassigned);
         return unassigned;
     }
@@ -116,7 +116,7 @@ public abstract class AbstractRuinStrategy implements RuinStrategy{
         if(jobIsInitial(job)) return false;
         boolean removed = route.getTourActivities().removeJob(job);
         if (removed) {
-            logger.trace("ruin: " + job.getId());
+            logger.trace("ruin: {}", job.getId());
             ruinListeners.removed(job,route);
             return true;
         }

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/JobNeighborhoodsImpl.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/JobNeighborhoodsImpl.java
@@ -26,7 +26,7 @@ class JobNeighborhoodsImpl implements JobNeighborhoods {
         super();
         this.vrp = vrp;
         this.jobDistance = jobDistance;
-        logger.debug("intialise " + this);
+        logger.debug("intialise {}", this);
     }
 
     @Override
@@ -86,8 +86,8 @@ class JobNeighborhoodsImpl implements JobNeighborhoods {
 
         }
         stopWatch.stop();
-        logger.debug("preprocessing comp-time: " + stopWatch + "; nuOfDistances stored: " + nuOfDistancesStored + "; estimated memory: " +
-                (distanceNodeTree.keySet().size()*64+nuOfDistancesStored*92) + " bytes");
+        logger.debug("preprocessing comp-time: {}; nuOfDistances stored: {}; estimated memory: {}" +
+                " bytes", stopWatch, nuOfDistancesStored, (distanceNodeTree.keySet().size()*64+nuOfDistancesStored*92) );
     }
 
 }

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/JobNeighborhoodsImplWithCapRestriction.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/JobNeighborhoodsImplWithCapRestriction.java
@@ -29,7 +29,7 @@ class JobNeighborhoodsImplWithCapRestriction implements JobNeighborhoods {
         this.vrp = vrp;
         this.jobDistance = jobDistance;
         this.capacity = capacity;
-        logger.debug("intialise " + this);
+        logger.debug("intialise {}", this);
     }
 
     @Override
@@ -59,7 +59,7 @@ class JobNeighborhoodsImplWithCapRestriction implements JobNeighborhoods {
 
     @Override
     public void initialise(){
-        logger.debug("calculates distances from EACH job to EACH job --> n^2="+Math.pow(vrp.getJobs().values().size(), 2) + " calculations, but 'only' "+(vrp.getJobs().values().size()*capacity)+ " are cached.");
+        logger.debug("calculates distances from EACH job to EACH job --> n^2={} calculations, but 'only' {} are cached.", Math.pow(vrp.getJobs().values().size(), 2), (vrp.getJobs().values().size()*capacity));
         if(capacity==0) return;
         calculateDistancesFromJob2Job();
     }
@@ -101,8 +101,8 @@ class JobNeighborhoodsImplWithCapRestriction implements JobNeighborhoods {
 
         }
         stopWatch.stop();
-        logger.debug("preprocessing comp-time: " + stopWatch + "; nuOfDistances stored: " + nuOfDistancesStored + "; estimated memory: " +
-                (distanceNodeTree.keySet().size()*64+nuOfDistancesStored*92) + " bytes");
+        logger.debug("preprocessing comp-time: {}; nuOfDistances stored: {}; estimated memory: {}" +
+                 " bytes", stopWatch, nuOfDistancesStored, (distanceNodeTree.keySet().size()*64+nuOfDistancesStored*92));
     }
 
     @Override

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/RuinClusters.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/RuinClusters.java
@@ -87,7 +87,7 @@ public final class RuinClusters extends AbstractRuinStrategy implements Iteratio
 			}
 		});
 		this.jobNeighborhoods = jobNeighborhoods;
-        logger.debug("initialise " + this);
+        logger.debug("initialise {}", this);
 	}
 
 	public void setNoClusters(int noClusters) {

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/RuinRadial.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/RuinRadial.java
@@ -68,7 +68,7 @@ public final class RuinRadial extends AbstractRuinStrategy {
 		JobNeighborhoodsImplWithCapRestriction jobNeighborhoodsImpl = new JobNeighborhoodsImplWithCapRestriction(vrp, jobDistance, noJobsToMemorize);
 		jobNeighborhoodsImpl.initialise();
 		jobNeighborhoods = jobNeighborhoodsImpl;
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 
 	public RuinRadial(VehicleRoutingProblem vrp, int noJobs2beRemoved, JobDistance jobDistance) {
@@ -87,7 +87,7 @@ public final class RuinRadial extends AbstractRuinStrategy {
 		JobNeighborhoodsImplWithCapRestriction jobNeighborhoodsImpl = new JobNeighborhoodsImplWithCapRestriction(vrp, jobDistance, noJobsToMemorize);
 		jobNeighborhoodsImpl.initialise();
 		jobNeighborhoods = jobNeighborhoodsImpl;
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 
 	public RuinRadial(VehicleRoutingProblem vrp, int noJobs2beRemoved, JobNeighborhoods neighborhoods) {
@@ -103,7 +103,7 @@ public final class RuinRadial extends AbstractRuinStrategy {
 
 		};
 		jobNeighborhoods = neighborhoods;
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 	
 	@Override

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/RuinRadialMultipleCenters.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/RuinRadialMultipleCenters.java
@@ -62,7 +62,7 @@ public final class RuinRadialMultipleCenters extends AbstractRuinStrategy {
 		JobNeighborhoodsImplWithCapRestriction jobNeighborhoodsImpl = new JobNeighborhoodsImplWithCapRestriction(vrp, jobDistance, noJobsToMemorize);
 		jobNeighborhoodsImpl.initialise();
 		jobNeighborhoods = jobNeighborhoodsImpl;
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 
 	public void setNumberOfRuinCenters(int noCenters){

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/RuinRandom.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/RuinRandom.java
@@ -60,7 +60,7 @@ public final class RuinRandom extends AbstractRuinStrategy {
 				return selectNuOfJobs2BeRemoved();
 			}
 		});
-        logger.debug("initialise " + this);
+        logger.debug("initialise {}", this);
 	}
 
 	/**

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/RuinWorst.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/ruin/RuinWorst.java
@@ -64,7 +64,7 @@ public final class RuinWorst extends AbstractRuinStrategy {
 				return initialNumberJobsToRemove;
 			}
 		});
-        logger.debug("initialise " + this);
+        logger.debug("initialise {}", this);
 	}
 
 	/**

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/termination/TimeTermination.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/termination/TimeTermination.java
@@ -70,7 +70,7 @@ public class TimeTermination implements PrematureAlgorithmTermination, Algorithm
 	public TimeTermination(long timeThreshold_in_milliseconds) {
 		super();
 		this.timeThreshold = timeThreshold_in_milliseconds;
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 
     public void setTimeGetter(TimeGetter timeGetter) {

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/termination/VariationCoefficientTermination.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/termination/VariationCoefficientTermination.java
@@ -73,7 +73,7 @@ public class VariationCoefficientTermination implements PrematureAlgorithmTermin
 		this.noIterations = noIterations;
 		this.variationCoefficientThreshold = variationCoefficientThreshold;
 		solutionValues = new double[noIterations];
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 	
 	@Override

--- a/jsprit-core/src/main/java/jsprit/core/problem/VehicleRoutingProblem.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/VehicleRoutingProblem.java
@@ -321,7 +321,7 @@ public class VehicleRoutingProblem {
 		}
 		
 		private void addShipment(Shipment job) {
-			if(jobs.containsKey(job.getId())){ logger.warn("job " + job + " already in job list. overrides existing job."); }
+			if(jobs.containsKey(job.getId())){ logger.warn("job {} already in job list. overrides existing job.", job); }
 			tentative_coordinates.put(job.getPickupLocation().getId(), job.getPickupLocation().getCoordinate());
 			tentative_coordinates.put(job.getDeliveryLocation().getId(), job.getDeliveryLocation().getCoordinate());
 			jobs.put(job.getId(),job);
@@ -472,7 +472,7 @@ public class VehicleRoutingProblem {
 
 		private Builder addService(Service service){
 			tentative_coordinates.put(service.getLocation().getId(), service.getLocation().getCoordinate());
-			if(jobs.containsKey(service.getId())){ logger.warn("service " + service + " already in job list. overrides existing job."); }
+			if(jobs.containsKey(service.getId())){ logger.warn("service {} already in job list. overrides existing job.", service); }
 			jobs.put(service.getId(),service);
 			return this;
 		}
@@ -554,7 +554,7 @@ public class VehicleRoutingProblem {
 		this.locations = builder.getLocations();
         this.activityMap = builder.activityMap;
         this.nuActivities = builder.activityIndexCounter;
-		logger.info("setup problem: " + this);
+		logger.info("setup problem: {}", this);
 	}
 
     @Override

--- a/jsprit-core/src/main/java/jsprit/core/problem/io/VrpXMLReader.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/io/VrpXMLReader.java
@@ -137,7 +137,7 @@ public class VrpXMLReader{
 	}
 	
 	public void read(String filename) {
-		logger.debug("read vrp: " + filename);
+		logger.debug("read vrp: {}", filename);
 		XMLConfiguration xmlConfig = new XMLConfiguration();
 		xmlConfig.setFileName(filename);
 		xmlConfig.setAttributeSplittingDisabled(true);
@@ -166,7 +166,7 @@ public class VrpXMLReader{
 		try {
 			xmlConfig.load();
 		} catch (ConfigurationException e) {
-			logger.error(e);
+			logger.error("Exception:", e);
 			e.printStackTrace();
 			System.exit(1);
 		}

--- a/jsprit-core/src/main/java/jsprit/core/problem/io/VrpXMLWriter.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/io/VrpXMLWriter.java
@@ -117,7 +117,7 @@ public class VrpXMLWriter {
 			element.setAttribute("xsi:schemaLocation","http://www.w3schools.com vrp_xml_schema.xsd");
 						
 		} catch (ConfigurationException e) {
-			logger.error(e);
+			logger.error("Exception:", e);
 			e.printStackTrace();
 			System.exit(1);
 		} 
@@ -128,7 +128,7 @@ public class VrpXMLWriter {
 			serializer.serialize(xmlConfig.getDocument());
 			out.close();
 		} catch (IOException e) {
-			logger.error(e);
+			logger.error("Exception:", e);
 			e.printStackTrace();
 			System.exit(1);
 		}

--- a/jsprit-core/src/main/java/jsprit/core/problem/vehicle/InfiniteVehicles.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/vehicle/InfiniteVehicles.java
@@ -37,7 +37,7 @@ class InfiniteVehicles implements VehicleFleetManager{
 		
 	public InfiniteVehicles(Collection<Vehicle> vehicles){
 		extractTypes(vehicles);
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 	
 	@Override

--- a/jsprit-core/src/main/java/jsprit/core/problem/vehicle/VehicleFleetManagerImpl.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/vehicle/VehicleFleetManagerImpl.java
@@ -76,7 +76,7 @@ class VehicleFleetManagerImpl implements VehicleFleetManager {
 		this.vehicles = vehicles;
 		this.lockedVehicles = new HashSet<Vehicle>();
 		makeMap();
-		logger.debug("initialise " + this);
+		logger.debug("initialise {}", this);
 	}
 
 	@Override

--- a/jsprit-instances/src/main/java/jsprit/instance/reader/ChristofidesReader.java
+++ b/jsprit-instances/src/main/java/jsprit/instance/reader/ChristofidesReader.java
@@ -111,7 +111,7 @@ public class ChristofidesReader {
 			reader.close();
 		} catch (IOException e) {
 			e.printStackTrace();
-			logger.error(e);
+			logger.error("Exception:", e);
 			System.exit(1);
 		}
 	}
@@ -121,7 +121,7 @@ public class ChristofidesReader {
 			return reader.readLine();
 		} catch (IOException e) {
 			e.printStackTrace();
-			logger.error(e);
+			logger.error("Exception:", e);
 			System.exit(1);
 			return null;
 		}
@@ -139,7 +139,7 @@ public class ChristofidesReader {
 			reader = new BufferedReader(new FileReader(solomonFile));
 		} catch (FileNotFoundException e1) {
 			e1.printStackTrace();
-			logger.error(e1);
+			logger.error("Exception:", e1);
 			System.exit(1);
 		}
 		return reader;

--- a/jsprit-instances/src/main/java/jsprit/instance/reader/CordeauReader.java
+++ b/jsprit-instances/src/main/java/jsprit/instance/reader/CordeauReader.java
@@ -141,7 +141,7 @@ public class CordeauReader {
 			reader.close();
 		} catch (IOException e) {
 			e.printStackTrace();
-			logger.error(e);
+			logger.error("Exception:", e);
 			System.exit(1);
 		}
 	}
@@ -151,7 +151,7 @@ public class CordeauReader {
 			return reader.readLine();
 		} catch (IOException e) {
 			e.printStackTrace();
-			logger.error(e);
+			logger.error("Exception:", e);
 			System.exit(1);
 			return null;
 		}
@@ -169,7 +169,7 @@ public class CordeauReader {
 			reader = new BufferedReader(new FileReader(solomonFile));
 		} catch (FileNotFoundException e1) {
 			e1.printStackTrace();
-			logger.error(e1);
+			logger.error("Exception:", e1);
 			System.exit(1);
 		}
 		return reader;

--- a/jsprit-instances/src/main/java/jsprit/instance/reader/LiLimReader.java
+++ b/jsprit-instances/src/main/java/jsprit/instance/reader/LiLimReader.java
@@ -142,7 +142,7 @@ public class LiLimReader {
 			reader = new BufferedReader(new FileReader(file));
 		} catch (FileNotFoundException e1) {
 			e1.printStackTrace();
-			logger.error(e1);
+			logger.error("Exception:", e1);
 			System.exit(1);
 		}
 		return reader;

--- a/jsprit-instances/src/main/java/jsprit/instance/reader/LopezIbanezBlumReader.java
+++ b/jsprit-instances/src/main/java/jsprit/instance/reader/LopezIbanezBlumReader.java
@@ -90,7 +90,7 @@ public class LopezIbanezBlumReader {
             reader.close();
         } catch (IOException e) {
             e.printStackTrace();
-            logger.error(e);
+            logger.error("Exception:", e);
             System.exit(1);
         }
     }
@@ -100,7 +100,7 @@ public class LopezIbanezBlumReader {
             return reader.readLine();
         } catch (IOException e) {
             e.printStackTrace();
-            logger.error(e);
+            logger.error("Exception:", e);
             System.exit(1);
             return null;
         }
@@ -112,7 +112,7 @@ public class LopezIbanezBlumReader {
             reader = new BufferedReader(new FileReader(solomonFile));
         } catch (FileNotFoundException e1) {
             e1.printStackTrace();
-            logger.error(e1);
+            logger.error("Exception:", e1);
             System.exit(1);
         }
         return reader;

--- a/jsprit-instances/src/main/java/jsprit/instance/reader/LuiShenReader.java
+++ b/jsprit-instances/src/main/java/jsprit/instance/reader/LuiShenReader.java
@@ -154,7 +154,7 @@ public class LuiShenReader {
 			reader.close();
 		} catch (IOException e) {
 			e.printStackTrace();
-			logger.error(e);
+			logger.error("Exception:", e);
 			System.exit(1);
 		}
 	}
@@ -164,7 +164,7 @@ public class LuiShenReader {
 			return reader.readLine();
 		} catch (IOException e) {
 			e.printStackTrace();
-			logger.error(e);
+			logger.error("Exception:", e);
 			System.exit(1);
 			return null;
 		}
@@ -182,7 +182,7 @@ public class LuiShenReader {
 			reader = new BufferedReader(new FileReader(solomonFile));
 		} catch (FileNotFoundException e1) {
 			e1.printStackTrace();
-			logger.error(e1);
+			logger.error("Exception:", e1);
 			System.exit(1);
 		}
 		return reader;

--- a/jsprit-instances/src/main/java/jsprit/instance/reader/SolomonReader.java
+++ b/jsprit-instances/src/main/java/jsprit/instance/reader/SolomonReader.java
@@ -130,7 +130,7 @@ public class SolomonReader {
 			reader.close();
 		} catch (IOException e) {
 			e.printStackTrace();
-			logger.error(e);
+			logger.error("Exception:", e);
 			System.exit(1);
 		}
 	}
@@ -140,7 +140,7 @@ public class SolomonReader {
 			return reader.readLine();
 		} catch (IOException e) {
 			e.printStackTrace();
-			logger.error(e);
+			logger.error("Exception:", e);
 			System.exit(1);
 			return null;
 		}
@@ -158,7 +158,7 @@ public class SolomonReader {
 			reader = new BufferedReader(new FileReader(solomonFile));
 		} catch (FileNotFoundException e1) {
 			e1.printStackTrace();
-			logger.error(e1);
+			logger.error("Exception:", e1);
 			System.exit(1);
 		}
 		return reader;


### PR DESCRIPTION
Even though there isn't any logging in the constraint checking code there is still quite a bit of logging outputted at trace level.

I did some quick-n-dirty tests on my machine:
- This change reduced the running time of the jsprit-core unit tests in IntelliJ by +-10 sec (from ~1:45 to 1:35).
- Weirdly, running `mvn verify` from the commandline is much quicker in general (0:30 - 0:35) and did not show much improvement with the new logging code

Therefore, this change might not show too much improvement but I think it would still be worth the change :)