### PR TITLE
service builder: avoid unnecessary casting

### DIFF
--- a/jsprit-core/src/main/java/jsprit/core/problem/job/Delivery.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/job/Delivery.java
@@ -24,7 +24,7 @@ package jsprit.core.problem.job;
  */
 public class Delivery extends Service {
 
-    public static class Builder extends Service.Builder {
+    public static class Builder extends Service.Builder<Delivery> {
 
         /**
          * Returns a new instance of builder that builds a delivery.

--- a/jsprit-core/src/main/java/jsprit/core/problem/job/Pickup.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/job/Pickup.java
@@ -24,7 +24,7 @@ package jsprit.core.problem.job;
  */
 public class Pickup extends Service {
 
-    public static class Builder extends Service.Builder {
+    public static class Builder extends Service.Builder<Pickup> {
 
         /**
          * Returns a new instance of builder that builds a pickup.

--- a/jsprit-core/src/main/java/jsprit/core/problem/job/Service.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/job/Service.java
@@ -152,14 +152,6 @@ public class Service extends AbstractJob {
             return this;
         }
 
-        protected T create() {
-            if (location == null) throw new IllegalStateException("location is missing");
-            this.setType("service");
-            capacity = capacityBuilder.build();
-            skills = skillBuilder.build();
-            return (T) new Service(this);
-        }
-        
         /**
          * Builds the service.
          *

--- a/jsprit-core/src/main/java/jsprit/core/problem/job/Service.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/job/Service.java
@@ -41,7 +41,7 @@ public class Service extends AbstractJob {
      *
      * @author schroeder
      */
-    public static class Builder {
+    public static class Builder <T extends Service> {
 
 
         /**
@@ -90,7 +90,7 @@ public class Service extends AbstractJob {
          * @param name the name of service
          * @return the builder
          */
-        protected Builder setType(String name) {
+        protected Builder<T> setType(String name) {
             this.type = name;
             return this;
         }
@@ -101,7 +101,7 @@ public class Service extends AbstractJob {
          * @param location location
          * @return builder
          */
-        public Builder setLocation(Location location) {
+        public Builder<T> setLocation(Location location) {
             this.location = location;
             return this;
         }
@@ -131,7 +131,7 @@ public class Service extends AbstractJob {
          * @return the builder
          * @throws IllegalArgumentException if dimensionValue < 0
          */
-        public Builder addSizeDimension(int dimensionIndex, int dimensionValue) {
+        public Builder<T> addSizeDimension(int dimensionIndex, int dimensionValue) {
             if (dimensionValue < 0) throw new IllegalArgumentException("capacity value cannot be negative");
             capacityBuilder.addDimension(dimensionIndex, dimensionValue);
             return this;
@@ -146,32 +146,40 @@ public class Service extends AbstractJob {
          * @return builder
          * @throws IllegalArgumentException if timeWindow is null
          */
-        public Builder setTimeWindow(TimeWindow tw) {
+        public Builder<T> setTimeWindow(TimeWindow tw) {
             if (tw == null) throw new IllegalArgumentException("time-window arg must not be null");
             this.timeWindow = tw;
             return this;
         }
 
+        protected T create() {
+            if (location == null) throw new IllegalStateException("location is missing");
+            this.setType("service");
+            capacity = capacityBuilder.build();
+            skills = skillBuilder.build();
+            return (T) new Service(this);
+        }
+        
         /**
          * Builds the service.
          *
          * @return {@link Service}
          * @throws IllegalStateException if neither locationId nor coordinate is set.
          */
-        public Service build() {
+        public T build() {
             if (location == null) throw new IllegalStateException("location is missing");
             this.setType("service");
             capacity = capacityBuilder.build();
             skills = skillBuilder.build();
-            return new Service(this);
+            return (T) new Service(this);
         }
 
-        public Builder addRequiredSkill(String skill) {
+        public Builder<T> addRequiredSkill(String skill) {
             skillBuilder.addSkill(skill);
             return this;
         }
 
-        public Builder setName(String name) {
+        public Builder<T> setName(String name) {
             this.name = name;
             return this;
         }

--- a/jsprit-core/src/test/java/jsprit/core/algorithm/RefuseCollection_IT.java
+++ b/jsprit-core/src/test/java/jsprit/core/algorithm/RefuseCollection_IT.java
@@ -267,7 +267,7 @@ public class RefuseCollection_IT {
 			/*
 			 * build service
 			 */
-            Pickup service = (Pickup) Pickup.Builder.newInstance(lineTokens[0]).addSizeDimension(0, Integer.parseInt(lineTokens[1]))
+            Pickup service = Pickup.Builder.newInstance(lineTokens[0]).addSizeDimension(0, Integer.parseInt(lineTokens[1]))
                 .setLocation(Location.newInstance(lineTokens[0])).build();
 			/*
 			 * and add it to problem

--- a/jsprit-examples/src/main/java/jsprit/examples/SimpleDepotBoundedPickupAndDeliveryExample.java
+++ b/jsprit-examples/src/main/java/jsprit/examples/SimpleDepotBoundedPickupAndDeliveryExample.java
@@ -62,11 +62,11 @@ public class SimpleDepotBoundedPickupAndDeliveryExample {
 		/*
          * build pickups and deliveries at the required locations, each with a capacity-demand of 1.
 		 */
-        Pickup pickup1 = (Pickup) Pickup.Builder.newInstance("1").addSizeDimension(0, 1).setLocation(Location.newInstance(5, 7)).build();
-        Delivery delivery1 = (Delivery) Delivery.Builder.newInstance("2").addSizeDimension(0, 1).setLocation(Location.newInstance(5, 13)).build();
+        Pickup pickup1 = Pickup.Builder.newInstance("1").addSizeDimension(0, 1).setLocation(Location.newInstance(5, 7)).build();
+        Delivery delivery1 = Delivery.Builder.newInstance("2").addSizeDimension(0, 1).setLocation(Location.newInstance(5, 13)).build();
 
-        Pickup pickup2 = (Pickup) Pickup.Builder.newInstance("3").addSizeDimension(0, 1).setLocation(Location.newInstance(15, 7)).build();
-        Delivery delivery2 = (Delivery) Delivery.Builder.newInstance("4").addSizeDimension(0, 1).setLocation(Location.newInstance(15, 13)).build();
+        Pickup pickup2 = Pickup.Builder.newInstance("3").addSizeDimension(0, 1).setLocation(Location.newInstance(15, 7)).build();
+        Delivery delivery2 =  Delivery.Builder.newInstance("4").addSizeDimension(0, 1).setLocation(Location.newInstance(15, 13)).build();
 
 
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();

--- a/jsprit-examples/src/main/java/jsprit/examples/SimpleVRPWithBackhaulsExample.java
+++ b/jsprit-examples/src/main/java/jsprit/examples/SimpleVRPWithBackhaulsExample.java
@@ -65,11 +65,11 @@ public class SimpleVRPWithBackhaulsExample {
 		/*
          * build pickups and deliveries at the required locations, each with a capacity-demand of 1.
 		 */
-        Pickup pickup1 = (Pickup) Pickup.Builder.newInstance("1").addSizeDimension(0, 1).setLocation(Location.newInstance(5, 7)).build();
-        Delivery delivery1 = (Delivery) Delivery.Builder.newInstance("2").addSizeDimension(0, 1).setLocation(Location.newInstance(5, 13)).build();
+        Pickup pickup1 = Pickup.Builder.newInstance("1").addSizeDimension(0, 1).setLocation(Location.newInstance(5, 7)).build();
+        Delivery delivery1 = Delivery.Builder.newInstance("2").addSizeDimension(0, 1).setLocation(Location.newInstance(5, 13)).build();
 
-        Pickup pickup2 = (Pickup) Pickup.Builder.newInstance("3").addSizeDimension(0, 1).setLocation(Location.newInstance(15, 7)).build();
-        Delivery delivery2 = (Delivery) Delivery.Builder.newInstance("4").addSizeDimension(0, 1).setLocation(Location.newInstance(15, 13)).build();
+        Pickup pickup2 = Pickup.Builder.newInstance("3").addSizeDimension(0, 1).setLocation(Location.newInstance(15, 7)).build();
+        Delivery delivery2 = Delivery.Builder.newInstance("4").addSizeDimension(0, 1).setLocation(Location.newInstance(15, 13)).build();
 
 
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();


### PR DESCRIPTION
We can use generics to avoid unnecessary casting