### PR TITLE
Add parameter in xsd schema to set fastRegret from configuration

### DIFF
--- a/jsprit-core/src/main/java/jsprit/core/algorithm/io/InsertionFactory.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/io/InsertionFactory.java
@@ -103,6 +103,11 @@ class InsertionFactory {
 
             if (insertionName.equals("regretInsertion")) {
                 iBuilder.setInsertionStrategy(InsertionBuilder.Strategy.REGRET);
+
+                String fastRegret = config.getString("fastRegret");
+                if (fastRegret != null) {
+                    iBuilder.setFastRegret(Boolean.parseBoolean(fastRegret));
+                }
             }
             return iBuilder.build();
         } else throw new IllegalStateException("cannot create insertionStrategy, since it has no name.");

--- a/jsprit-core/src/main/resources/algorithm_schema.xsd
+++ b/jsprit-core/src/main/resources/algorithm_schema.xsd
@@ -248,6 +248,7 @@
                 </xs:complexType>
             </xs:element>
             <xs:element name="allowVehicleSwitch" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="fastRegret" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
             <xs:element name="experimental" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
                     <xs:sequence>


### PR DESCRIPTION
Hello,
My colleagues and I are using your library for our university assignment on VRP. We are settings the parameters for the solver from a config.xml file. It was not possible for us to use the new fastRegret option without drastically change our code without the parameter in the schema.
If there are any problem I'm available to modify my PR.

The `fastRegret` option is considered only if `regretInsertion` has been set as the preferred insertion strategy.

Thanks in advance!